### PR TITLE
Fixed 2 compiler warnings of this type: String interpolation produces…

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -78,7 +78,9 @@ routes.add(method: .get, uri: "/api/v1/check", handler: {
 
 	var resp = [String: String]()
 	resp["authenticated"] = "AUTHED: \(request.user.authenticated)"
-	resp["SessionID"] = "SessionID: \(request.user.authDetails?.account.uniqueID)"
+	
+	let sessionIdValue: String = String(describing: request.user.authDetails?.account.uniqueID)
+	resp["SessionID"] = "SessionID: \(sessionIdValue)"
 
 	do {
 		try response.setBody(json: resp)
@@ -96,7 +98,9 @@ routes.add(method: .get, uri: "/api/v1/nocheck", handler: {
 
 	var resp = [String: String]()
 	resp["authenticated"] = "AUTHED: \(request.user.authenticated)"
-	resp["authDetails"] = "DETAILS: \(request.user.authDetails)"
+
+	let authDetailsValue: String = String(describing: request.user.authDetails)
+	resp["authDetails"] = "DETAILS: \(authDetailsValue)"
 
 	do {
 		try response.setBody(json: resp)


### PR DESCRIPTION
… a debug description for an optional value; did you mean to make this explicit? Use 'String(describing:)' to silence this warning, Provide a default value to avoid this warning